### PR TITLE
Atualização de normas NBR 10520/2023

### DIFF
--- a/ABNT_Author.XSL
+++ b/ABNT_Author.XSL
@@ -308,15 +308,15 @@
       <list name="citation" id="1">
         <single_prefix></single_prefix>
         <multi_prefix></multi_prefix>
-        <corporate>{%Corporate:u%}</corporate>
-        <first_person>{%Last:u%}</first_person>
-        <other_persons>{%Last:u%}</other_persons>
+        <corporate>{%Corporate%}</corporate>
+        <first_person>{%Last%}</first_person>
+        <other_persons>{%Last%}</other_persons>
         <separator_between_if_two> e </separator_between_if_two>
         <separator_between_if_more_than_two>, </separator_between_if_more_than_two>
         <separator_before_last> e </separator_before_last>
         <max_number_of_persons_to_display>3</max_number_of_persons_to_display>
-        <number_of_persons_to_display_if_more_than_max>2</number_of_persons_to_display_if_more_than_max>
-        <overflow>, &lt;i&gt;et al.&lt;/i&gt;</overflow>
+        <number_of_persons_to_display_if_more_than_max>1</number_of_persons_to_display_if_more_than_max>
+        <overflow> &lt;i&gt;et al.&lt;/i&gt;</overflow>
         <single_suffix></single_suffix>
         <multi_suffix></multi_suffix>
       </list>


### PR DESCRIPTION
Segundo a revisão da NBR 10520/2023, agora as citações indiretas não são mais em caixa alta:

![image](https://github.com/thiagodp/abnt-no-word/assets/21264708/861dffa1-1d80-458d-91c7-51513006e3da)

Fonte: https://www.normasabnt.org/

E a segunda alteração que fiz, é que no caso de citação indireta com +3 autores, apenas o primeiro aparece seguido de _et al_, e antigamente eram os 2 primeiros.

PS: Excelente trabalho neste repo!! Gostaria de ir atualizando caso fosse possível, me ajudou muito.